### PR TITLE
修改shadowsocks.sh脚本的BUG，gfwlist不生效

### DIFF
--- a/apps/shadowsocks/scripts/shadowsocks.sh
+++ b/apps/shadowsocks/scripts/shadowsocks.sh
@@ -8,6 +8,7 @@ eval `mbdb export shadowsocks`
 [ -z "$ss_proxy_default_mode" ] && ss_proxy_default_mode=1
 [ -z "$ss_game_default_mode" ] && ss_game_default_mode=0
 [ -z "$dns_red_ip" ] && dns_red_ip="$lanip"
+[ "$ssgena" != "1" ] && unset ssg_mode
 
 get_v2ray_bin() {
 	result1=$(curl -skL $mburl/appsbin/v2ray-bin/$model/lastest.txt) &> /dev/null


### PR DESCRIPTION
发现判断的一处BUG。启用gfwlist的判断条件包含了`ssg_mode`这个变量。如果之前配置过，又去掉了游戏加速模式的话，这个判断就有问题。因此一个简单的解决方案就是，如果`ssgna != 1`(游戏加速未启用)，则unset掉`ssg_mode`