### PR TITLE
解决BT无法全速下载问题

### DIFF
--- a/apps/aria2/config/aria2.conf
+++ b/apps/aria2/config/aria2.conf
@@ -42,6 +42,11 @@ max-upload-limit=0
 #referer=*
 #文件保存路径, 默认为当前启动位置
 dir=/extdisks/sda1/下载
+#IPv4 DHT routing table file to PATH(IPV6默认没有打开的)
+#dht-file-path=/extdisks/sda1/下载/.aria2/dht.dat
+#dht-file-path6=/extdisks/sda1/下载/.aria2/dht6.dat
+#bt-tracker
+#bt-tracker=
 #文件缓存, 使用内置的文件缓存, 如果你不相信Linux内核文件缓存和磁盘内置缓存时使用, 需要1.16及以上版本
 #disk-cache=0
 #另一种Linux文件缓存方式, 使用前确保您使用的内核支持此选项, 需要1.15及以上版本(?)

--- a/apps/aria2/scripts/aria2.sh
+++ b/apps/aria2/scripts/aria2.sh
@@ -31,6 +31,14 @@ set_config() {
 
 	[ ! -d "$path" ] && mkdir -p $path
 
+    # DHT 缓存目录配置
+    if [ ! -d "${path}/.aria2" ]; then
+        mkdir -p "${path}/.aria2"
+        # IPV6默认没有开，可以不用配置
+        sed -i "s#.*dht-file-path.*#dht-file-path=${path}/.aria2/dht.dat#" ${mbroot}/apps/${appname}/config/${appname}.conf
+        sed -i "s#.*dht-file-path6.*#dht-file-path6=${path}/.aria2/dht6.dat#" ${mbroot}/apps/${appname}/config/${appname}.conf
+    fi
+
     # 自动更新bt-tracker
     list=`curl -s https://raw.githubusercontent.com/ngosang/trackerslist/master/trackers_best.txt|awk NF|sed ":a;N;s/\n/,/g;ta"`
     if [ ! -z "${list}" ]; then

--- a/apps/aria2/scripts/aria2.sh
+++ b/apps/aria2/scripts/aria2.sh
@@ -9,6 +9,11 @@ WEBDIR=${mbroot}/apps/${appname}/web
 aria2url=http://$lanip/backup/log/${appname}
 binname=aria2c
 
+open_ports() {
+    # 添加bt下载和DHT监听端口
+    open_port 6881:6999 tcp
+}
+
 set_config() {
 
 	logsh "【$service】" "加载${appname}配置..."

--- a/apps/aria2/scripts/aria2.sh
+++ b/apps/aria2/scripts/aria2.sh
@@ -31,6 +31,13 @@ set_config() {
 
 	[ ! -d "$path" ] && mkdir -p $path
 
+    # 自动更新bt-tracker
+    list=`curl -s https://raw.githubusercontent.com/ngosang/trackerslist/master/trackers_best.txt|awk NF|sed ":a;N;s/\n/,/g;ta"`
+    if [ ! -z "${list}" ]; then
+        sed -i "s#.*bt-tracker.*#bt-tracker=${list}#" ${mbroot}/apps/${appname}/config/${appname}.conf
+        logsh "【$service】" "更新bt-tracker"
+    fi
+
 	#R3加载库文件
 	[ "$xq" == "R3" -o "$xq" == "R1CM" ] && export LD_LIBRARY_PATH=${mbroot}/apps/${appname}/lib:/usr/lib:/lib
 


### PR DESCRIPTION
1. 添加bt下载和DHT监听端口；  
2.DHT 缓存目录配置；  
3.自动更新bt-tracker；  
PS：DHT 缓存目录配置那段代码是参照你之前的代码写的，创建目录那块我没有测，我本地是手动建的文件夹，但我检查了代码逻辑应该没有问题。